### PR TITLE
Update README.md with node version req.

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,8 @@ for await (var update of subscription_iterator) {
 
 ## Using it in Nodejs
 
+You need node version > 20 
+
 ### Example Nodejs server with `require('http')`
 
 Braidify adds these fields and methods to requests and responses:


### PR DESCRIPTION
I had a hard time tracking a bug that came from using nvm 18 ( braid-http is using Blob which is only available on node 20 )